### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/sort/index.ts
+++ b/src/sort/index.ts
@@ -23,7 +23,7 @@ class Sort {
     this.set({ sorts: this.extractSorts() })
 
   extractSorts() {
-    const sorts = Selectors.sorts(this.flux.store.getState());
+    const sorts = this.select(Selectors.sorts);
     return sorts.items.map((sort, index) => ({
       label: this.getLabel(sort, index),
       selected: sorts.selected === index

--- a/test/unit/sort.ts
+++ b/test/unit/sort.ts
@@ -77,12 +77,11 @@ suite('Sort', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias })
       const sort1 = { field: 'variant.colour', descending: true };
       const sort2 = { field: 'price' };
       const sort3 = { field: 'size', descending: true };
-      const selectSorts = stub(Selectors, 'sorts').returns({ items: [sort1, sort2, sort3], selected: 1 });
-      sort.flux = <any>{ store: { getState: () => state } };
+      const select = sort.select = spy(() => ({ items: [sort1, sort2, sort3], selected: 1 }));
 
       const options = sort.extractSorts();
 
-      expect(selectSorts).to.be.calledWithExactly(state);
+      expect(select).to.be.calledWithExactly(Selectors.sorts);
       expect(getLabel).to.be.calledWith(sort1, 0);
       expect(getLabel).to.be.calledWith(sort2, 1);
       expect(getLabel).to.be.calledWith(sort3, 2);


### PR DESCRIPTION
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
