### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/sort/index.html
+++ b/src/sort/index.html
@@ -1,3 +1,3 @@
 <yield>
-  <gb-select options="{ state.sorts }" on-select="{ state.onSelect }"></gb-select>
+  <gb-select options="{state.sorts}" on-select="{state.onSelect}"></gb-select>
 </yield>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.